### PR TITLE
Add packaging info, Fedora install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Several installation methods are provided based on your platform. If none of the
 
 ### Fedora
 
-You can install Astroterm directly from the [Fedora package repository](https://packages.fedoraproject.org/pkgs/astroterm/astroterm) on Fedora 40+.
+You can install `astroterm` directly from the [Fedora package repository](https://packages.fedoraproject.org/pkgs/astroterm/astroterm) on Fedora 40+.
 
 ```sh
 sudo dnf install astroterm

--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ _<p align="center">Stars over Sydney, Australia on January 6, 2025</p>_
 
 Several installation methods are provided based on your platform. If none of these fit your needs, you can always [build from source](#building-from-source). Refer to [troubleshooting](#troubleshooting) for help resolving any issues.
 
+[![Packaging status](https://repology.org/badge/vertical-allrepos/astroterm.svg)](https://repology.org/project/astroterm/versions)
+
+### Fedora
+
+You can install Astroterm directly from the [Fedora package repository](https://packages.fedoraproject.org/pkgs/astroterm/astroterm) on Fedora 40+.
+
+```sh
+sudo dnf install astroterm
+```
+
 ### Homebrew
 
 You can install Astroterm directly from the [custom Homebrew tap](https://github.com/da-luce/homebrew-astroterm):

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ _<p align="center">The night sky above Singapore on January 2, 2025</p>_
 - [🌌 astroterm](#-astroterm)
   - [Features](#features)
   - [Installation](#installation)
+    - [Fedora](#fedora)
     - [Homebrew](#homebrew)
     - [Nix](#nix)
     - [Prebuilt Executable](#prebuilt-executable)


### PR DESCRIPTION
The Fedora link/command will start working tonight when our "compose" runs (when new builds are synced to the master mirror and repodata is rebuilt, basically).

Please do not merge this until Jan 22 US time.

I listed Fedora first as the existing 2 instruction sets where in alphabetical order so I retained it.  If you want it ordered differently I'm happy to move it.

Fixes #48 