### PR TITLE
Update nix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,13 @@ Argument flags are added by wrapping the command in quotes. For example:
 nix-shell -I nixpkgs=channel:nixpkgs-unstable -p astroterm --command "astroterm -u -c"
 ```
 
-To make `astroterm` available from your `$PATH`, install it with:
+To make `astroterm` available from your `$PATH`, add it to your configuration.nix:
 
 ```sh
-nix-env -f channel:nixpkgs-unstable -iA astroterm
+environment.systemPackages = with pkgs; [
+  ...
+  astroterm
+]
 ```
 
 ### Guix


### PR DESCRIPTION
It is generally discouraged to use nix-env to install packages: """
Warning: Using nix-env permanently modifies a local profile of installed packages. This must be updated and maintained by the user in the same way as with a traditional package manager, foregoing many of the benefits that make Nix uniquely powerful. Using nix-shell or a NixOS configuration is recommended instead.  """
See for example 
https://search.nixos.org/packages?channel=25.05&show=astroterm&from=0&size=50&sort=relevance&type=packages&query=astroterm