### PR TITLE
Fix: SIGFPE when drawing grid

### DIFF
--- a/src/core_render.c
+++ b/src/core_render.c
@@ -270,7 +270,7 @@ void render_azimuthal_grid(WINDOW *win, const struct Conf *config)
     for (int i = 0; i < length; ++i)
     {
         // Vertical offset (rows) of the angle at edge of window -- approximately the "arc length" for small angles
-        int vertical_offset = (int) round(rad_vertical * sin(step_sizes[i] * to_rad));
+        int vertical_offset = (int)round(rad_vertical * sin(step_sizes[i] * to_rad));
         if (vertical_offset >= min_height)
         {
             inc = step_sizes[i];


### PR DESCRIPTION
Hello and thank you for this really fun program!
Fixes #73. For large resolutions the `step_sizes` array index `i` was decremented to `-1`, leading to `0` value and SIGFPE. Fix by incrementing instead. This does lead to less dense grid lines than before this change, but given the comment this seems like the intended behaviour.
By the way are there any plans for more configurability of the grid lines?