### PR TITLE
Add equator and ecliptic overlays (#109)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ Usage: astroterm [OPTION]...
   -C, --constellations      Draw constellation stick figures. Note: a
                             constellation is only drawn if all stars in the
                             figure are over the threshold
+  -e, --equator             Draw the celestial equator on the polar projection
+  -E, --ecliptic            Draw the ecliptic on the polar projection
   -g, --grid                Draw an azimuthal grid
   -u, --unicode             Use unicode characters
   -b, --braille             Use braille characters for constellation lines

--- a/include/arg_definitions.h
+++ b/include/arg_definitions.h
@@ -51,6 +51,8 @@ INCLUDE_ARG_DEFINITION_LIT0(color_arg, "c", "color", "Enable terminal colors");
 INCLUDE_ARG_DEFINITION_LIT0(
     constell_arg, "C", "constellations",
     "Draw constellation stick figures. Note: a constellation is only drawn if all stars in the figure are over the threshold");
+INCLUDE_ARG_DEFINITION_LIT0(equator_arg, "e", "equator", "Draw the celestial equator on the polar projection");
+INCLUDE_ARG_DEFINITION_LIT0(ecliptic_arg, "E", "ecliptic", "Draw the ecliptic on the polar projection");
 INCLUDE_ARG_DEFINITION_LIT0(grid_arg, "g", "grid", "Draw an azimuthal grid");
 INCLUDE_ARG_DEFINITION_LIT0(unicode_arg, "u", "unicode", "Use unicode characters");
 INCLUDE_ARG_DEFINITION_LIT0(braille_arg, "b", "braille", "Use braille characters for constellation lines (requires Unicode)");

--- a/include/coord.h
+++ b/include/coord.h
@@ -59,6 +59,11 @@ void equatorial_to_horizontal(double right_ascension, double declination, double
  */
 void equatorial_rectangular_to_spherical(double xeq, double yeq, double zeq, double *right_ascension, double *declination);
 
+/* Converts ecliptic coordinates to equatorial coordinates using the J2000
+ * obliquity of the ecliptic.
+ */
+void ecliptic_to_equatorial(double ecliptic_longitude, double ecliptic_latitude, double *right_ascension, double *declination);
+
 /* Converts horizontal coordinates to spherical coordinates
  */
 void horizontal_to_spherical(double azimuth, double altitude, double *theta_sphere, double *phi_sphere);

--- a/include/core.h
+++ b/include/core.h
@@ -28,6 +28,8 @@ struct Conf
     bool braille;
     bool color;
     bool grid;
+    bool equator;
+    bool ecliptic;
     bool constell;
     bool metadata;
 };

--- a/include/core_render.h
+++ b/include/core_render.h
@@ -25,6 +25,10 @@ void render_moon_stereo(WINDOW *win, const struct Conf *config, struct Moon moon
 void render_constells(WINDOW *win, const struct Conf *config, struct Constell **constell_table, int num_const,
                       const struct Star *star_table);
 
+/* Render celestial reference circles on the polar projection.
+ */
+void render_reference_circles(WINDOW *win, const struct Conf *config);
+
 /* Render an azimuthal grid on a stereographic projection
  */
 void render_azimuthal_grid(WINDOW *win, const struct Conf *config);

--- a/include/drawing.h
+++ b/include/drawing.h
@@ -36,6 +36,11 @@ void draw_line_ASCII(WINDOW *win, int ya, int xa, int yb, int xb);
  */
 void draw_line_smooth(WINDOW *win, int ya, int xa, int yb, int xb);
 
+/* Draw a connected polyline in screen coordinates, choosing glyphs from the
+ * combined connectivity at each cell so adjacent segments share proper joints.
+ */
+void draw_polyline_connected(WINDOW *win, const int *rows, const int *cols, int count, bool unicode);
+
 /* Draw an dotted line segment from (xa, ya) and (xb, yb) where y and x
  * are synonymous with row and column, respectively.
  */

--- a/src/coord.c
+++ b/src/coord.c
@@ -11,6 +11,21 @@ void equatorial_rectangular_to_spherical(double xeq, double yeq, double zeq, dou
     *declination = atan2(zeq, sqrt(xeq * xeq + yeq * yeq));
 }
 
+void ecliptic_to_equatorial(double ecliptic_longitude, double ecliptic_latitude, double *right_ascension, double *declination)
+{
+    const double obliquity = 84381.448 / (60.0 * 60.0) * TO_RAD;
+
+    *right_ascension =
+        atan2(sin(ecliptic_longitude) * cos(obliquity) - tan(ecliptic_latitude) * sin(obliquity), cos(ecliptic_longitude));
+    if (*right_ascension < 0.0)
+    {
+        *right_ascension += 2.0 * M_PI;
+    }
+
+    *declination =
+        asin(sin(ecliptic_latitude) * cos(obliquity) + cos(ecliptic_latitude) * sin(obliquity) * sin(ecliptic_longitude));
+}
+
 void equatorial_to_horizontal(double right_ascension, double declination, double gmst, double latitude, double longitude,
                               double *azimuth, double *altitude)
 {

--- a/src/core_render.c
+++ b/src/core_render.c
@@ -10,6 +10,12 @@
 #include <math.h>
 #include <stdlib.h>
 
+enum
+{
+    EQUATOR_COLOR_PAIR = 5,
+    ECLIPTIC_COLOR_PAIR = 4,
+};
+
 void horizontal_to_polar(double azimuth, double altitude, double *radius, double *theta)
 {
     double theta_sphere, phi_sphere;
@@ -18,6 +24,124 @@ void horizontal_to_polar(double azimuth, double altitude, double *radius, double
     project_stereographic_north(1.0, theta_sphere, phi_sphere, radius, theta);
 
     return;
+}
+
+static void equatorial_to_polar_projected(double right_ascension, double declination, double gmst, const struct Conf *config,
+                                          double *radius_polar, double *theta_polar)
+{
+    double azimuth, altitude;
+    equatorial_to_horizontal(right_ascension, declination, gmst, config->latitude, config->longitude, &azimuth, &altitude);
+    horizontal_to_polar(azimuth, altitude, radius_polar, theta_polar);
+}
+
+static void append_polyline_point(int *rows, int *cols, int *count, int y, int x)
+{
+    if (*count > 0 && rows[*count - 1] == y && cols[*count - 1] == x)
+    {
+        return;
+    }
+
+    rows[*count] = y;
+    cols[*count] = x;
+    *count += 1;
+}
+
+static void render_reference_circle(WINDOW *win, const struct Conf *config, bool ecliptic, int color_pair)
+{
+    int height, width;
+    getmaxyx(win, height, width);
+
+    int samples = MAX(height, width) * 4;
+    if (samples < 180)
+    {
+        samples = 180;
+    }
+
+    int *rows = malloc((size_t)(samples + 1) * sizeof(int));
+    int *cols = malloc((size_t)(samples + 1) * sizeof(int));
+    if (rows == NULL || cols == NULL)
+    {
+        free(rows);
+        free(cols);
+        return;
+    }
+
+    double gmst = greenwich_mean_sidereal_time_rad(config->julian_date);
+    double radius_prev, theta_prev;
+    double right_ascension = 0.0;
+    double declination = 0.0;
+
+    if (ecliptic)
+    {
+        ecliptic_to_equatorial(0.0, 0.0, &right_ascension, &declination);
+    }
+
+    equatorial_to_polar_projected(right_ascension, declination, gmst, config, &radius_prev, &theta_prev);
+
+    bool use_color = config->color && color_pair != 0;
+    if (use_color)
+    {
+        wattron(win, COLOR_PAIR(color_pair));
+    }
+
+    int point_count = 0;
+
+    for (int i = 1; i <= samples; ++i)
+    {
+        double angle = 2.0 * M_PI * i / samples;
+
+        if (ecliptic)
+        {
+            ecliptic_to_equatorial(angle, 0.0, &right_ascension, &declination);
+        }
+        else
+        {
+            right_ascension = angle;
+            declination = 0.0;
+        }
+
+        double radius_curr, theta_curr;
+        equatorial_to_polar_projected(right_ascension, declination, gmst, config, &radius_curr, &theta_curr);
+
+        bool prev_visible = fabs(radius_prev) <= 1.0;
+        bool curr_visible = fabs(radius_curr) <= 1.0;
+
+        if (prev_visible || curr_visible)
+        {
+            int ya, xa;
+            int yb, xb;
+            polar_to_win(fmin(radius_prev, 1.0), theta_prev, height, width, &ya, &xa);
+            polar_to_win(fmin(radius_curr, 1.0), theta_curr, height, width, &yb, &xb);
+
+            append_polyline_point(rows, cols, &point_count, ya, xa);
+            append_polyline_point(rows, cols, &point_count, yb, xb);
+        }
+        else if (point_count > 1)
+        {
+            draw_polyline_connected(win, rows, cols, point_count, config->unicode);
+            point_count = 0;
+        }
+        else
+        {
+            point_count = 0;
+        }
+
+        radius_prev = radius_curr;
+        theta_prev = theta_curr;
+    }
+
+    if (point_count > 1)
+    {
+        draw_polyline_connected(win, rows, cols, point_count, config->unicode);
+    }
+
+    if (use_color)
+    {
+        wattroff(win, COLOR_PAIR(color_pair));
+    }
+
+    free(rows);
+    free(cols);
 }
 
 void render_object_stereo(WINDOW *win, struct ObjectBase *object, const struct Conf *config)
@@ -205,6 +329,19 @@ void render_constells(WINDOW *win, const struct Conf *config, struct Constell **
     {
         struct Constell *constellation = &((*constell_table)[i]);
         render_constellation(win, config, constellation, star_table);
+    }
+}
+
+void render_reference_circles(WINDOW *win, const struct Conf *config)
+{
+    if (config->equator)
+    {
+        render_reference_circle(win, config, false, EQUATOR_COLOR_PAIR);
+    }
+
+    if (config->ecliptic)
+    {
+        render_reference_circle(win, config, true, ECLIPTIC_COLOR_PAIR);
     }
 }
 

--- a/src/drawing.c
+++ b/src/drawing.c
@@ -216,6 +216,228 @@ void draw_line_smooth(WINDOW *win, int ya, int xa, int yb, int xb)
     }
 }
 
+enum Connectivity
+{
+    CONN_NORTH = 1 << 0,
+    CONN_EAST = 1 << 1,
+    CONN_SOUTH = 1 << 2,
+    CONN_WEST = 1 << 3,
+};
+
+static bool point_in_bounds(int y, int x, int height, int width)
+{
+    return y >= 0 && y < height && x >= 0 && x < width;
+}
+
+static void add_connection(unsigned char *mask, int height, int width, int ya, int xa, int yb, int xb)
+{
+    if (!point_in_bounds(ya, xa, height, width) || !point_in_bounds(yb, xb, height, width))
+    {
+        return;
+    }
+
+    unsigned int index_a = (unsigned int)ya * (unsigned int)width + (unsigned int)xa;
+    unsigned int index_b = (unsigned int)yb * (unsigned int)width + (unsigned int)xb;
+
+    if (ya == yb)
+    {
+        if (xb == xa + 1)
+        {
+            mask[index_a] |= CONN_EAST;
+            mask[index_b] |= CONN_WEST;
+        }
+        else if (xb == xa - 1)
+        {
+            mask[index_a] |= CONN_WEST;
+            mask[index_b] |= CONN_EAST;
+        }
+    }
+    else if (xa == xb)
+    {
+        if (yb == ya + 1)
+        {
+            mask[index_a] |= CONN_SOUTH;
+            mask[index_b] |= CONN_NORTH;
+        }
+        else if (yb == ya - 1)
+        {
+            mask[index_a] |= CONN_NORTH;
+            mask[index_b] |= CONN_SOUTH;
+        }
+    }
+}
+
+static void rasterize_connected_segment(unsigned char *mask, int height, int width, int ya, int xa, int yb, int xb)
+{
+    int dy = yb - ya;
+    int dx = xb - xa;
+
+    if (dy == 0 && dx == 0)
+    {
+        return;
+    }
+
+    if (abs(dy) > abs(dx))
+    {
+        int y = 0;
+        double x = 0.0;
+        int sy = (dy > 0) ? 1 : -1;
+        double sx = (double)dx / abs(dy);
+
+        while (abs(y) < abs(dy))
+        {
+            int curr_y = ya + y;
+            int curr_x = xa + (int)round(x);
+
+            int next_y = ya + y + sy;
+            int next_x = xa + (int)round(x + sx);
+
+            if (curr_x != next_x && curr_x != xb)
+            {
+                add_connection(mask, height, width, curr_y, curr_x, curr_y, next_x);
+                add_connection(mask, height, width, curr_y, next_x, next_y, next_x);
+            }
+            else
+            {
+                add_connection(mask, height, width, curr_y, curr_x, next_y, curr_x);
+            }
+
+            y += sy;
+            x += sx;
+        }
+    }
+    else
+    {
+        double y = 0.0;
+        int x = 0;
+        double sy = (double)dy / abs(dx);
+        int sx = (dx > 0) ? 1 : -1;
+
+        while (abs(x) < abs(dx))
+        {
+            int curr_y = ya + (int)round(y);
+            int curr_x = xa + x;
+
+            int next_y = ya + (int)round(y + sy);
+            int next_x = xa + x + sx;
+
+            if (curr_y != next_y && curr_y != yb)
+            {
+                add_connection(mask, height, width, curr_y, curr_x, next_y, curr_x);
+                add_connection(mask, height, width, next_y, curr_x, next_y, next_x);
+            }
+            else
+            {
+                add_connection(mask, height, width, curr_y, curr_x, curr_y, next_x);
+            }
+
+            y += sy;
+            x += sx;
+        }
+    }
+}
+
+static const char *smooth_connectivity_glyph(unsigned char mask)
+{
+    switch (mask)
+    {
+    case CONN_NORTH:
+    case CONN_SOUTH:
+    case CONN_NORTH | CONN_SOUTH:
+        return "│";
+    case CONN_EAST:
+    case CONN_WEST:
+    case CONN_EAST | CONN_WEST:
+        return "─";
+    case CONN_NORTH | CONN_EAST:
+        return "╰";
+    case CONN_NORTH | CONN_WEST:
+        return "╯";
+    case CONN_SOUTH | CONN_EAST:
+        return "╭";
+    case CONN_SOUTH | CONN_WEST:
+        return "╮";
+    case CONN_NORTH | CONN_SOUTH | CONN_EAST:
+        return "├";
+    case CONN_NORTH | CONN_SOUTH | CONN_WEST:
+        return "┤";
+    case CONN_EAST | CONN_WEST | CONN_SOUTH:
+        return "┬";
+    case CONN_EAST | CONN_WEST | CONN_NORTH:
+        return "┴";
+    case CONN_NORTH | CONN_EAST | CONN_SOUTH | CONN_WEST:
+        return "┼";
+    default:
+        return NULL;
+    }
+}
+
+static char ascii_connectivity_glyph(unsigned char mask)
+{
+    switch (mask)
+    {
+    case CONN_NORTH:
+    case CONN_SOUTH:
+    case CONN_NORTH | CONN_SOUTH:
+        return '|';
+    case CONN_EAST:
+    case CONN_WEST:
+    case CONN_EAST | CONN_WEST:
+        return '-';
+    default:
+        return '+';
+    }
+}
+
+void draw_polyline_connected(WINDOW *win, const int *rows, const int *cols, int count, bool unicode)
+{
+    if (count < 2)
+    {
+        return;
+    }
+
+    int height, width;
+    getmaxyx(win, height, width);
+
+    unsigned char *mask = calloc((size_t)height * (size_t)width, sizeof(unsigned char));
+    if (mask == NULL)
+    {
+        return;
+    }
+
+    for (int i = 0; i < count - 1; ++i)
+    {
+        rasterize_connected_segment(mask, height, width, rows[i], cols[i], rows[i + 1], cols[i + 1]);
+    }
+
+    for (int y = 0; y < height; ++y)
+    {
+        for (int x = 0; x < width; ++x)
+        {
+            unsigned char cell_mask = mask[(size_t)y * (size_t)width + (size_t)x];
+            if (cell_mask == 0)
+            {
+                continue;
+            }
+
+            if (unicode)
+            {
+                const char *glyph = smooth_connectivity_glyph(cell_mask);
+                if (glyph != NULL)
+                {
+                    mvwaddstr(win, y, x, glyph);
+                }
+            }
+            else
+            {
+                mvwaddch(win, y, x, ascii_connectivity_glyph(cell_mask));
+            }
+        }
+    }
+
+    free(mask);
+}
+
 void draw_line_dotted(WINDOW *win, int ya, int xa, int yb, int xb)
 {
     // The logic here is not particularly elegant or efficient

--- a/src/main.c
+++ b/src/main.c
@@ -68,6 +68,8 @@ int main(int argc, char *argv[])
         .braille = false,
         .color = false,
         .grid = false,
+        .equator = false,
+        .ecliptic = false,
         .constell = false,
         .metadata = false,
     };
@@ -170,8 +172,10 @@ int main(int argc, char *argv[])
         update_planet_positions(planet_table, julian_date, config.latitude, config.longitude);
         update_moon_position(&moon_object, julian_date, config.latitude, config.longitude);
         update_moon_phase(&moon_object, julian_date, config.latitude);
+        config.julian_date = julian_date;
 
         // Render objects
+        render_reference_circles(main_win, &config);
         render_stars_stereo(main_win, &config, star_table, num_stars, num_by_mag);
         if (config.constell)
         {
@@ -278,11 +282,12 @@ void parse_options(int argc, char *argv[], struct Conf *config)
 #define INCLUDE_ARG_DEFINITION_INT0(token, short_name, long_name, datatype, glossary)                                          \
     struct arg_int *token = arg_int0(short_name, long_name, datatype, glossary);
 #include "arg_definitions.h"
-    struct arg_end *end = arg_end(20);
+    struct arg_end *end = arg_end(22);
 
-    void *argtable[] = {latitude_arg, longitude_arg, datetime_arg,    threshold_arg, label_arg,   fps_arg,  speed_arg,
-                        color_arg,    constell_arg,  grid_arg,        unicode_arg,   braille_arg, quit_arg, meta_arg,
-                        ratio_arg,    help_arg,      completions_arg, city_arg,      version_arg, end};
+    void *argtable[] = {latitude_arg, longitude_arg, datetime_arg, threshold_arg, label_arg,       fps_arg,     speed_arg,
+                        color_arg,    constell_arg,  equator_arg,  ecliptic_arg,  grid_arg,        unicode_arg, braille_arg,
+                        quit_arg,     meta_arg,      ratio_arg,    help_arg,      completions_arg, city_arg,    version_arg,
+                        end};
 
     int nerrors = arg_parse(argc, argv, argtable);
 
@@ -421,6 +426,16 @@ void parse_options(int argc, char *argv[], struct Conf *config)
     if (meta_arg->count > 0)
     {
         config->metadata = true;
+    }
+
+    if (equator_arg->count > 0)
+    {
+        config->equator = true;
+    }
+
+    if (ecliptic_arg->count > 0)
+    {
+        config->ecliptic = true;
     }
 
     if (grid_arg->count > 0)

--- a/test/coord_test.c
+++ b/test/coord_test.c
@@ -45,6 +45,25 @@ void test_project_stereographic_top(void)
     TEST_ASSERT_FLOAT_WITHIN(0.01, expected_theta_polar, theta_polar);
 }
 
+void test_ecliptic_to_equatorial(void)
+{
+    double right_ascension;
+    double declination;
+    double obliquity = 84381.448 / (60.0 * 60.0) * TO_RAD;
+
+    ecliptic_to_equatorial(0.0, 0.0, &right_ascension, &declination);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001, 0.0, right_ascension);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001, 0.0, declination);
+
+    ecliptic_to_equatorial(M_PI / 2.0, 0.0, &right_ascension, &declination);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001, M_PI / 2.0, right_ascension);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001, obliquity, declination);
+
+    ecliptic_to_equatorial(M_PI, 0.0, &right_ascension, &declination);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001, M_PI, right_ascension);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001, 0.0, declination);
+}
+
 // polar_to_win
 
 void test_polar_to_win(void)
@@ -72,6 +91,7 @@ int main(void)
     UNITY_BEGIN();
 
     RUN_TEST(test_project_stereographic_top);
+    RUN_TEST(test_ecliptic_to_equatorial);
     RUN_TEST(test_polar_to_win);
 
     return UNITY_END();

--- a/test/coord_test.c
+++ b/test/coord_test.c
@@ -62,6 +62,10 @@ void test_ecliptic_to_equatorial(void)
     ecliptic_to_equatorial(M_PI, 0.0, &right_ascension, &declination);
     TEST_ASSERT_FLOAT_WITHIN(0.0001, M_PI, right_ascension);
     TEST_ASSERT_FLOAT_WITHIN(0.0001, 0.0, declination);
+
+    ecliptic_to_equatorial(3.0 * M_PI / 2.0, 0.0, &right_ascension, &declination);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001, 3.0 * M_PI / 2.0, right_ascension);
+    TEST_ASSERT_FLOAT_WITHIN(0.0001, -obliquity, declination);
 }
 
 // polar_to_win

--- a/test/drawing_test.c
+++ b/test/drawing_test.c
@@ -414,8 +414,200 @@ void test_connected_polyline_smooth_adjacent_corners(void)
     read_window_to_wide_array(win, actual, 2, 3);
 
     const wchar_t(*const_actual)[MAX_WINDOW_WIDTH] = (const wchar_t(*)[MAX_WINDOW_WIDTH])actual;
+    int matches = compare_wide_arrays(const_actual, connected_polyline_smooth_2x3, 2, 3);
 
-    TEST_ASSERT_TRUE(compare_wide_arrays(const_actual, connected_polyline_smooth_2x3, 2, 3));
+    TEST_ASSERT_EQUAL_INT(1, matches);
+
+    delwin(win);
+}
+
+// clang-format off
+const wchar_t connected_polyline_smooth_all_joints_3x5[MAX_WINDOW_HEIGHT][MAX_WINDOW_WIDTH] = {
+    L" ╭┬╮ ",
+    L" ├┼┤ ",
+    L" ╰┴╯ ",
+};
+// clang-format on
+
+void test_connected_polyline_smooth_all_joints(void)
+{
+    WINDOW *win = newwin(3, 5, 0, 0);
+    wchar_t actual[MAX_WINDOW_HEIGHT][MAX_WINDOW_WIDTH];
+
+    int rows[] = {0, 0, 1, 1, 0, 0, 1, 1, 2, 2, 1, 2, 2, 2, 1};
+    int cols[] = {2, 1, 1, 2, 2, 3, 3, 2, 2, 1, 1, 1, 2, 3, 3};
+
+    draw_polyline_connected(win, rows, cols, 15, true);
+
+    read_window_to_wide_array(win, actual, 3, 5);
+
+    const wchar_t(*const_actual)[MAX_WINDOW_WIDTH] = (const wchar_t(*)[MAX_WINDOW_WIDTH])actual;
+    int matches = compare_wide_arrays(const_actual, connected_polyline_smooth_all_joints_3x5, 3, 5);
+
+    TEST_ASSERT_EQUAL_INT(1, matches);
+
+    delwin(win);
+}
+
+// clang-format off
+const wchar_t connected_polyline_smooth_vertical_bend_4x2[MAX_WINDOW_HEIGHT][MAX_WINDOW_WIDTH] = {
+    L"│ ",
+    L"╰╮",
+    L" │",
+    L" │",
+};
+// clang-format on
+
+void test_connected_polyline_smooth_vertical_bend(void)
+{
+    WINDOW *win = newwin(4, 2, 0, 0);
+    wchar_t actual[MAX_WINDOW_HEIGHT][MAX_WINDOW_WIDTH];
+
+    int rows[] = {0, 3};
+    int cols[] = {0, 1};
+
+    draw_polyline_connected(win, rows, cols, 2, true);
+
+    read_window_to_wide_array(win, actual, 4, 2);
+
+    const wchar_t(*const_actual)[MAX_WINDOW_WIDTH] = (const wchar_t(*)[MAX_WINDOW_WIDTH])actual;
+    int matches = compare_wide_arrays(const_actual, connected_polyline_smooth_vertical_bend_4x2, 4, 2);
+
+    TEST_ASSERT_EQUAL_INT(1, matches);
+
+    delwin(win);
+}
+
+// clang-format off
+const wchar_t connected_polyline_smooth_horizontal_bend_2x4[MAX_WINDOW_HEIGHT][MAX_WINDOW_WIDTH] = {
+    L"─╮  ",
+    L" ╰──",
+};
+// clang-format on
+
+void test_connected_polyline_smooth_horizontal_bend(void)
+{
+    WINDOW *win = newwin(2, 4, 0, 0);
+    wchar_t actual[MAX_WINDOW_HEIGHT][MAX_WINDOW_WIDTH];
+
+    int rows[] = {0, 1};
+    int cols[] = {0, 3};
+
+    draw_polyline_connected(win, rows, cols, 2, true);
+
+    read_window_to_wide_array(win, actual, 2, 4);
+
+    const wchar_t(*const_actual)[MAX_WINDOW_WIDTH] = (const wchar_t(*)[MAX_WINDOW_WIDTH])actual;
+    int matches = compare_wide_arrays(const_actual, connected_polyline_smooth_horizontal_bend_2x4, 2, 4);
+
+    TEST_ASSERT_EQUAL_INT(1, matches);
+
+    delwin(win);
+}
+
+// -----------------------------------------------------------------------------
+// ASCII Connected Polyline
+// -----------------------------------------------------------------------------
+
+// clang-format off
+const char connected_polyline_ascii_3x3[MAX_WINDOW_HEIGHT][MAX_WINDOW_WIDTH] = {
+    "  |",
+    "  |",
+    "--+",
+};
+// clang-format on
+
+void test_connected_polyline_ascii(void)
+{
+    WINDOW *win = newwin(3, 3, 0, 0);
+    char actual[MAX_WINDOW_HEIGHT][MAX_WINDOW_WIDTH];
+
+    int rows[] = {2, 2, 0};
+    int cols[] = {0, 2, 2};
+
+    draw_polyline_connected(win, rows, cols, 3, false);
+
+    read_window_to_array(win, actual, 3, 3);
+
+    const char (*const_actual)[MAX_WINDOW_WIDTH] = (const char (*)[MAX_WINDOW_WIDTH])actual;
+    int matches = compare_arrays(const_actual, connected_polyline_ascii_3x3, 3, 3);
+
+    TEST_ASSERT_EQUAL_INT(1, matches);
+
+    delwin(win);
+}
+
+// clang-format off
+const wchar_t connected_polyline_count_too_small_1x1[MAX_WINDOW_HEIGHT][MAX_WINDOW_WIDTH] = {
+    L" ",
+};
+// clang-format on
+
+void test_connected_polyline_count_too_small(void)
+{
+    WINDOW *win = newwin(1, 1, 0, 0);
+    wchar_t actual[MAX_WINDOW_HEIGHT][MAX_WINDOW_WIDTH];
+
+    int rows[] = {0};
+    int cols[] = {0};
+
+    draw_polyline_connected(win, rows, cols, 1, true);
+
+    read_window_to_wide_array(win, actual, 1, 1);
+
+    const wchar_t(*const_actual)[MAX_WINDOW_WIDTH] = (const wchar_t(*)[MAX_WINDOW_WIDTH])actual;
+    int matches = compare_wide_arrays(const_actual, connected_polyline_count_too_small_1x1, 1, 1);
+
+    TEST_ASSERT_EQUAL_INT(1, matches);
+
+    delwin(win);
+}
+
+void test_connected_polyline_zero_length_segment(void)
+{
+    WINDOW *win = newwin(1, 1, 0, 0);
+    wchar_t actual[MAX_WINDOW_HEIGHT][MAX_WINDOW_WIDTH];
+
+    int rows[] = {0, 0};
+    int cols[] = {0, 0};
+
+    draw_polyline_connected(win, rows, cols, 2, true);
+
+    read_window_to_wide_array(win, actual, 1, 1);
+
+    const wchar_t(*const_actual)[MAX_WINDOW_WIDTH] = (const wchar_t(*)[MAX_WINDOW_WIDTH])actual;
+    int matches = compare_wide_arrays(const_actual, connected_polyline_count_too_small_1x1, 1, 1);
+
+    TEST_ASSERT_EQUAL_INT(1, matches);
+
+    delwin(win);
+}
+
+void test_connected_polyline_out_of_bounds(void)
+{
+    WINDOW *win = newwin(1, 1, 0, 0);
+    wchar_t actual[MAX_WINDOW_HEIGHT][MAX_WINDOW_WIDTH];
+
+    int rows_right[] = {0, 0};
+    int cols_right[] = {0, 1};
+    int rows_left[] = {0, 0};
+    int cols_left[] = {-1, 0};
+    int rows_above[] = {-1, 0};
+    int cols_above[] = {0, 0};
+    int rows_below[] = {1, 0};
+    int cols_below[] = {0, 0};
+
+    draw_polyline_connected(win, rows_right, cols_right, 2, true);
+    draw_polyline_connected(win, rows_left, cols_left, 2, true);
+    draw_polyline_connected(win, rows_above, cols_above, 2, true);
+    draw_polyline_connected(win, rows_below, cols_below, 2, true);
+
+    read_window_to_wide_array(win, actual, 1, 1);
+
+    const wchar_t(*const_actual)[MAX_WINDOW_WIDTH] = (const wchar_t(*)[MAX_WINDOW_WIDTH])actual;
+    int matches = compare_wide_arrays(const_actual, connected_polyline_count_too_small_1x1, 1, 1);
+
+    TEST_ASSERT_EQUAL_INT(1, matches);
 
     delwin(win);
 }
@@ -595,6 +787,13 @@ int main(void)
     RUN_TEST(test_vertical_smooth_11x11);
     RUN_TEST(test_horizontal_smooth_11x11);
     RUN_TEST(test_connected_polyline_smooth_adjacent_corners);
+    RUN_TEST(test_connected_polyline_smooth_all_joints);
+    RUN_TEST(test_connected_polyline_smooth_vertical_bend);
+    RUN_TEST(test_connected_polyline_smooth_horizontal_bend);
+    RUN_TEST(test_connected_polyline_ascii);
+    RUN_TEST(test_connected_polyline_count_too_small);
+    RUN_TEST(test_connected_polyline_zero_length_segment);
+    RUN_TEST(test_connected_polyline_out_of_bounds);
 
     RUN_TEST(test_vertical_braille_11x11);
     RUN_TEST(test_horizontal_braille_11x11);

--- a/test/drawing_test.c
+++ b/test/drawing_test.c
@@ -391,6 +391,36 @@ void test_horizontal_smooth_11x11(void)
 }
 
 // -----------------------------------------------------------------------------
+// Unicode Connected Polyline
+// -----------------------------------------------------------------------------
+
+// clang-format off
+const wchar_t connected_polyline_smooth_2x3[MAX_WINDOW_HEIGHT][MAX_WINDOW_WIDTH] = {
+    L" ╭─",
+    L"─╯ ",
+};
+// clang-format on
+
+void test_connected_polyline_smooth_adjacent_corners(void)
+{
+    WINDOW *win = newwin(2, 3, 0, 0);
+    wchar_t actual[MAX_WINDOW_HEIGHT][MAX_WINDOW_WIDTH];
+
+    int rows[] = {1, 1, 0, 0};
+    int cols[] = {0, 1, 1, 2};
+
+    draw_polyline_connected(win, rows, cols, 4, true);
+
+    read_window_to_wide_array(win, actual, 2, 3);
+
+    const wchar_t(*const_actual)[MAX_WINDOW_WIDTH] = (const wchar_t(*)[MAX_WINDOW_WIDTH])actual;
+
+    TEST_ASSERT_TRUE(compare_wide_arrays(const_actual, connected_polyline_smooth_2x3, 2, 3));
+
+    delwin(win);
+}
+
+// -----------------------------------------------------------------------------
 // Braille Vertical
 // -----------------------------------------------------------------------------
 
@@ -564,6 +594,7 @@ int main(void)
     RUN_TEST(test_diagonal_smooth_opposite_10x10);
     RUN_TEST(test_vertical_smooth_11x11);
     RUN_TEST(test_horizontal_smooth_11x11);
+    RUN_TEST(test_connected_polyline_smooth_adjacent_corners);
 
     RUN_TEST(test_vertical_braille_11x11);
     RUN_TEST(test_horizontal_braille_11x11);


### PR DESCRIPTION
## Summary
- add `--equator` and `--ecliptic` options for the polar projection
- render the celestial equator and ecliptic overlays
- draw the ecliptic in yellow when colors are enabled
- add test coverage for the new coordinate/rendering path
- fixes #109