### PR TITLE
refactor(city): inject CSV data into get_city and iter_cities (#106)

### DIFF
--- a/include/city.h
+++ b/include/city.h
@@ -8,16 +8,20 @@ typedef struct
     float longitude;
 } CityData;
 
-/* Attempt to get the coordinates of a city by name. Returns NULL if not found.
+/* Attempt to get the coordinates of a city by name from the provided CSV
+ * byte buffer. Returns NULL if not found. When multiple rows share the same
+ * normalized name, the one with the highest population is returned.
  */
-CityData *get_city(const char *name);
+CityData *get_city(const char *name, const unsigned char *data, unsigned int data_len);
 
 /* Free memory used by CityData struct.
  */
 void free_city(CityData *city);
 
-/* Apply a callback and some associated data to all city definitions
+/* Apply a callback and some associated data to every city row in the provided
+ * CSV byte buffer.
  */
-void iter_cities(void (*callback)(const CityData *city, void *data), void *data);
+void iter_cities(void (*callback)(const CityData *city, void *data), void *user_data,
+                 const unsigned char *data, unsigned int data_len);
 
 #endif // CITY_H

--- a/include/city.h
+++ b/include/city.h
@@ -21,7 +21,7 @@ void free_city(CityData *city);
 /* Apply a callback and some associated data to every city row in the provided
  * CSV byte buffer.
  */
-void iter_cities(void (*callback)(const CityData *city, void *data), void *user_data,
-                 const unsigned char *data, unsigned int data_len);
+void iter_cities(void (*callback)(const CityData *city, void *data), void *user_data, const unsigned char *data,
+                 unsigned int data_len);
 
 #endif // CITY_H

--- a/src/city.c
+++ b/src/city.c
@@ -1,5 +1,4 @@
 #include "city.h"
-#include "cities.h"
 #include "macros.h"
 #include "split_lines.h"
 
@@ -92,9 +91,9 @@ static int compare_city(const void *key, const void *element)
     return result;
 }
 
-CityData *get_city(const char *name)
+CityData *get_city(const char *name, const unsigned char *data, unsigned int data_len)
 {
-    if (name == NULL || cities_len == 0)
+    if (name == NULL || data == NULL || data_len == 0)
     {
         return NULL;
     }
@@ -106,23 +105,23 @@ CityData *get_city(const char *name)
         return NULL;
     }
 
-    char *data = malloc(cities_len + 1);
-    if (data == NULL)
+    char *buffer = malloc(data_len + 1);
+    if (buffer == NULL)
     {
         free(normalized_name);
         return NULL;
     }
 
-    memcpy(data, cities, cities_len);
-    data[cities_len] = '\0';
+    memcpy(buffer, data, data_len);
+    buffer[data_len] = '\0';
 
     // Convert the byte array into an array of lines
     int line_count = 0;
-    char **lines = split_lines(data, &line_count);
+    char **lines = split_lines(buffer, &line_count);
     if (lines == NULL)
     {
         free(normalized_name);
-        free(data);
+        free(buffer);
         return NULL;
     }
 
@@ -187,7 +186,7 @@ CityData *get_city(const char *name)
         free(lines[i]);
     }
     free(lines);
-    free(data);
+    free(buffer);
     free(normalized_name);
 
     return best_city;
@@ -213,23 +212,28 @@ void free_city(CityData *city)
  * @param user_data A pointer to user-defined data that will be passed to the
  *                  callback function for each city.
  */
-void iter_cities(void (*callback)(const CityData *city, void *data), void *user_data)
+void iter_cities(void (*callback)(const CityData *city, void *data), void *user_data,
+                 const unsigned char *data, unsigned int data_len)
 {
-    if (callback == NULL)
+    if (callback == NULL || data == NULL || data_len == 0)
     {
         return;
     }
 
-    // Get the city data as a buffer using split_lines
-    char *data = malloc(cities_len + 1);
-    memcpy(data, cities, cities_len);
-    data[cities_len] = '\0';
+    // Copy into a writable buffer since split_lines and strtok mutate the input
+    char *buffer = malloc(data_len + 1);
+    if (buffer == NULL)
+    {
+        return;
+    }
+    memcpy(buffer, data, data_len);
+    buffer[data_len] = '\0';
 
     int line_count = 0;
-    char **lines = split_lines(data, &line_count);
+    char **lines = split_lines(buffer, &line_count);
     if (lines == NULL)
     {
-        free(data);
+        free(buffer);
         return;
     }
 
@@ -262,5 +266,5 @@ void iter_cities(void (*callback)(const CityData *city, void *data), void *user_
         free(lines[i]);
     }
     free(lines);
-    free(data);
+    free(buffer);
 }

--- a/src/city.c
+++ b/src/city.c
@@ -212,8 +212,8 @@ void free_city(CityData *city)
  * @param user_data A pointer to user-defined data that will be passed to the
  *                  callback function for each city.
  */
-void iter_cities(void (*callback)(const CityData *city, void *data), void *user_data,
-                 const unsigned char *data, unsigned int data_len)
+void iter_cities(void (*callback)(const CityData *city, void *data), void *user_data, const unsigned char *data,
+                 unsigned int data_len)
 {
     if (callback == NULL || data == NULL || data_len == 0)
     {

--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,7 @@
 #include "bsc5.h"
 #include "bsc5_constellations.h"
 #include "bsc5_names.h"
+#include "cities.h"
 
 // Third party libraries
 #ifdef HAVE_ARGTABLE3
@@ -314,7 +315,7 @@ void parse_options(int argc, char *argv[], struct Conf *config)
 #include "arg_definitions.h"
         printf(")\n\n");
         printf("ASTROTERM_CITIES=(\n");
-        iter_cities(&print_city_name_quoted, NULL);
+        iter_cities(&print_city_name_quoted, NULL, cities, cities_len);
         printf(")\n");
         // Warning: this is a vibe code modified version from PR #80 in order to
         // get things working on bash 3.2. The cleaning of the input word seems
@@ -451,7 +452,7 @@ void parse_options(int argc, char *argv[], struct Conf *config)
     if (city_arg->count > 0)
     {
         const char *city_name = city_arg->sval[0];
-        CityData *city = get_city(city_name);
+        CityData *city = get_city(city_name, cities, cities_len);
 
         if (!city)
         {

--- a/test/city_test.c
+++ b/test/city_test.c
@@ -1,3 +1,4 @@
+#include "cities.h"
 #include "city.h"
 #include "unity.h"
 #include <string.h>
@@ -13,7 +14,7 @@ void tearDown(void)
 void test_get_city(void)
 {
     // Test for a city that exists
-    CityData *city = get_city("Tunis");
+    CityData *city = get_city("Tunis", cities, cities_len);
     TEST_ASSERT_NOT_NULL(city);
     TEST_ASSERT_EQUAL_STRING("Tunis", city->city_name);
     TEST_ASSERT_EQUAL_FLOAT(36.81897, city->latitude);
@@ -21,7 +22,7 @@ void test_get_city(void)
     free_city(city);
 
     // Test for another city that exists
-    city = get_city("Boston");
+    city = get_city("Boston", cities, cities_len);
     TEST_ASSERT_NOT_NULL(city);
     TEST_ASSERT_EQUAL_STRING("Boston", city->city_name);
     TEST_ASSERT_EQUAL_FLOAT(42.35843, city->latitude);
@@ -30,16 +31,15 @@ void test_get_city(void)
 
     // Test for cities with duplicate names. The larger should maintain the same
     // name
-    city = get_city("London");
+    city = get_city("London", cities, cities_len);
     TEST_ASSERT_NOT_NULL(city);
     TEST_ASSERT_EQUAL_STRING("London", city->city_name);
     TEST_ASSERT_EQUAL_FLOAT(51.50853, city->latitude);
     TEST_ASSERT_EQUAL_FLOAT(-0.12574, city->longitude);
     free_city(city);
-    // TODO: test other "London"
 
     // Test for yet another city that exists
-    city = get_city("Lisbon");
+    city = get_city("Lisbon", cities, cities_len);
     TEST_ASSERT_NOT_NULL(city);
     TEST_ASSERT_EQUAL_STRING("Lisbon", city->city_name);
     TEST_ASSERT_EQUAL_FLOAT(38.72509, city->latitude);
@@ -47,7 +47,7 @@ void test_get_city(void)
     free_city(city);
 
     // Test for a city with mixed case and spaces (regression test for PR #79)
-    city = get_city("Rio de Janeiro");
+    city = get_city("Rio de Janeiro", cities, cities_len);
     TEST_ASSERT_NOT_NULL(city);
     TEST_ASSERT_EQUAL_STRING("Rio de Janeiro", city->city_name);
     TEST_ASSERT_EQUAL_FLOAT(-22.90642, city->latitude);
@@ -55,7 +55,7 @@ void test_get_city(void)
     free_city(city);
 
     // Test for a city with non-ASCII characters
-    city = get_city("Thủ Dầu Một");
+    city = get_city("Thủ Dầu Một", cities, cities_len);
     TEST_ASSERT_NOT_NULL(city);
     TEST_ASSERT_EQUAL_STRING("Thủ Dầu Một", city->city_name);
     TEST_ASSERT_EQUAL_FLOAT(10.9804, city->latitude);
@@ -63,16 +63,53 @@ void test_get_city(void)
     free_city(city);
 
     // Test for a city that does not exist
-    city = get_city("NonexistentCity");
+    city = get_city("NonexistentCity", cities, cities_len);
     TEST_ASSERT_NULL(city);
 
     // Ensure small population locations are not present
-    city = get_city("Nantucket");
+    city = get_city("Nantucket", cities, cities_len);
     TEST_ASSERT_NULL(city);
 
     // Test for a null input
-    city = get_city(NULL);
+    city = get_city(NULL, cities, cities_len);
     TEST_ASSERT_NULL(city);
+
+    // Test for null data
+    city = get_city("Boston", NULL, 0);
+    TEST_ASSERT_NULL(city);
+}
+
+// Verify that when a name is duplicated in the input CSV, the row with the
+// highest population is returned regardless of the order the rows appear in.
+// Before PR #79 a binary-search approach could satisfy the original order but
+// not its reverse, so we test both orderings here.
+void test_get_city_duplicate_names(void)
+{
+    // CSV schema: city_name,population,country_code,timezone,latitude,longitude
+    // Two "London" rows with different populations; the ~8.9M entry must win.
+    const unsigned char small_first[] =
+        "city_name,population,country_code,timezone,latitude,longitude\n"
+        "London,1000,CA,America/Toronto,42.98339,-81.23304\n"
+        "London,8900000,GB,Europe/London,51.50853,-0.12574\n";
+
+    CityData *city = get_city("London", small_first, (unsigned int)(sizeof(small_first) - 1));
+    TEST_ASSERT_NOT_NULL(city);
+    TEST_ASSERT_EQUAL_STRING("London", city->city_name);
+    TEST_ASSERT_EQUAL_FLOAT(51.50853, city->latitude);
+    TEST_ASSERT_EQUAL_FLOAT(-0.12574, city->longitude);
+    free_city(city);
+
+    const unsigned char big_first[] =
+        "city_name,population,country_code,timezone,latitude,longitude\n"
+        "London,8900000,GB,Europe/London,51.50853,-0.12574\n"
+        "London,1000,CA,America/Toronto,42.98339,-81.23304\n";
+
+    city = get_city("London", big_first, (unsigned int)(sizeof(big_first) - 1));
+    TEST_ASSERT_NOT_NULL(city);
+    TEST_ASSERT_EQUAL_STRING("London", city->city_name);
+    TEST_ASSERT_EQUAL_FLOAT(51.50853, city->latitude);
+    TEST_ASSERT_EQUAL_FLOAT(-0.12574, city->longitude);
+    free_city(city);
 }
 
 // -----------------------------------------------------------------------------
@@ -108,7 +145,7 @@ void test_iter_cities_should_iterate_all_rows(void)
 {
     int city_count = 0;
 
-    iter_cities(count_cities_cb, &city_count);
+    iter_cities(count_cities_cb, &city_count, cities, cities_len);
 
     // We expect the count to be greater than 0 if data/cities.csv is loaded
     // properly
@@ -120,7 +157,7 @@ void test_iter_cities_should_parse_data_correctly(void)
     // results array: [found_flag, latitude, longitude]
     float results[3] = {0.0f, 0.0f, 0.0f};
 
-    iter_cities(find_boston_cb, results);
+    iter_cities(find_boston_cb, results, cities, cities_len);
 
     TEST_ASSERT_EQUAL_FLOAT_MESSAGE(1.0f, results[0], "Boston was not found during iteration");
     TEST_ASSERT_EQUAL_FLOAT(42.35843, results[1]);
@@ -130,10 +167,17 @@ void test_iter_cities_should_parse_data_correctly(void)
 void test_iter_cities_null_callback_should_not_crash(void)
 {
     // Passing NULL as the callback should return immediately
-    iter_cities(NULL, NULL);
+    iter_cities(NULL, NULL, cities, cities_len);
 
     // Sentinel assertion to ensure test passes if we get here without crashing
     TEST_ASSERT_TRUE(1);
+}
+
+void test_iter_cities_null_data_should_not_crash(void)
+{
+    int city_count = 0;
+    iter_cities(count_cities_cb, &city_count, NULL, 0);
+    TEST_ASSERT_EQUAL_INT(0, city_count);
 }
 
 int main(void)
@@ -141,10 +185,12 @@ int main(void)
     UNITY_BEGIN();
 
     RUN_TEST(test_get_city);
+    RUN_TEST(test_get_city_duplicate_names);
 
     RUN_TEST(test_iter_cities_should_iterate_all_rows);
     RUN_TEST(test_iter_cities_should_parse_data_correctly);
     RUN_TEST(test_iter_cities_null_callback_should_not_crash);
+    RUN_TEST(test_iter_cities_null_data_should_not_crash);
 
     return UNITY_END();
 }

--- a/test/city_test.c
+++ b/test/city_test.c
@@ -87,10 +87,9 @@ void test_get_city_duplicate_names(void)
 {
     // CSV schema: city_name,population,country_code,timezone,latitude,longitude
     // Two "London" rows with different populations; the ~8.9M entry must win.
-    const unsigned char small_first[] =
-        "city_name,population,country_code,timezone,latitude,longitude\n"
-        "London,1000,CA,America/Toronto,42.98339,-81.23304\n"
-        "London,8900000,GB,Europe/London,51.50853,-0.12574\n";
+    const unsigned char small_first[] = "city_name,population,country_code,timezone,latitude,longitude\n"
+                                        "London,1000,CA,America/Toronto,42.98339,-81.23304\n"
+                                        "London,8900000,GB,Europe/London,51.50853,-0.12574\n";
 
     CityData *city = get_city("London", small_first, (unsigned int)(sizeof(small_first) - 1));
     TEST_ASSERT_NOT_NULL(city);
@@ -99,10 +98,9 @@ void test_get_city_duplicate_names(void)
     TEST_ASSERT_EQUAL_FLOAT(-0.12574, city->longitude);
     free_city(city);
 
-    const unsigned char big_first[] =
-        "city_name,population,country_code,timezone,latitude,longitude\n"
-        "London,8900000,GB,Europe/London,51.50853,-0.12574\n"
-        "London,1000,CA,America/Toronto,42.98339,-81.23304\n";
+    const unsigned char big_first[] = "city_name,population,country_code,timezone,latitude,longitude\n"
+                                      "London,8900000,GB,Europe/London,51.50853,-0.12574\n"
+                                      "London,1000,CA,America/Toronto,42.98339,-81.23304\n";
 
     city = get_city("London", big_first, (unsigned int)(sizeof(big_first) - 1));
     TEST_ASSERT_NOT_NULL(city);


### PR DESCRIPTION
## Summary

Un-hardcodes `get_city` and `iter_cities` per issue #106. Both functions now take a CSV byte buffer and its length as explicit parameters instead of reading the `cities.h` globals directly.

- `main.c` passes `cities, cities_len` to both call sites, so end-user behavior is unchanged.
- `test/city_test.c` updates to pass the same arguments for all existing tests, confirming the default path still works.

## Why

The issue calls out that duplicate-name handling is hard to test when the function only reads from a compiled-in global. The only way to stress it is via the full `cities.csv` and we can't easily guarantee both orderings of a given name are present.

## The new test

`test_get_city_duplicate_names` feeds two tiny two-row CSV fixtures with a `London` in each ordering:

```
London,1000,CA,...          London,8900000,GB,...
London,8900000,GB,...   vs  London,1000,CA,...
```

and asserts the ~8.9M row wins either way. This would have caught the binary-search regression fixed in PR #79 directly.

Also added `test_iter_cities_null_data_should_not_crash` since the new parameter adds a new null-handling path.

## Test plan

- [x] `meson test -C build city_test` — 6/6 pass (was 4/4 before, +2 new)
- [x] `meson test -C build` — 8/8 suites pass
- [x] `./build/astroterm --help` — binary still runs
- [x] No changes to `cities.csv` or `cities.h` generation

Closes #106
